### PR TITLE
Fix setup.py: build external cython modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ setup(
     name="savar",
     version="0.3",
     #  packages=["savar"],
-    py_modules=['savar', 'savar.dim_methods', "savar.spatial_models", "savar.eval_tools", "savar.functions",
+    py_modules=['savar', 'savar.dim_methods', "savar.old_spatial_models", "savar.eval_tools", "savar.functions",
                 "savar.model_generator", "savar.savar"],
     requires=['numpy', 'scipy', 'tigramite', 'matplotlib'],
+    ext_modules=cythonize(["./savar/c_functions.pyx","./savar/c_dim_methods.pyx"]),
+    zip_safe=False,
     include_dirs=[numpy.get_include()])


### PR DESCRIPTION
- build external cython modules (c_functions and c_dim_methods)
- correct the name of the python module savar.spatial_models to savar.old_spatial_models